### PR TITLE
Use inttypes.h macros for platform independent printing of uint64_t

### DIFF
--- a/builtins.c
+++ b/builtins.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <inttypes.h>
 
 #include "objects.h"
 #include "data.h"
@@ -109,7 +110,7 @@ scm bltn_display_port(void) ALIGN {
 		to = port_get_file(port);
 	}
 	else {
-		printf("DBG tag %lu\n", scm_gettag(atom));
+		printf("DBG tag %" PRIu64 "\n", scm_gettag(atom));
 		info_assert("not a port" == 0);
 	}
 
@@ -141,7 +142,7 @@ void display_helper(FILE *to, scm atom) {
 		break;
 	
 	case TAG_NUMB:
-		fprintf(to, "%ld", get_numb(atom));
+		fprintf(to, "%" PRId64, get_numb(atom));
 		break;
 
 	case TAG_STRG:
@@ -149,7 +150,7 @@ void display_helper(FILE *to, scm atom) {
 		break;
 
 	default:
-		fprintf(stderr, "Unsupported type in call to print, atom=%lu\n", atom);
+		fprintf(stderr, "Unsupported type in call to print, atom=%" PRIu64 "\n", atom);
 		break;
 	}
 }

--- a/data.c
+++ b/data.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <string.h>
 #include <search.h>
+#include <inttypes.h>
 
 #include "objects.h"
 #include "data.h"
@@ -50,7 +51,7 @@ void vm_add_codeword(scm w)
 void vm_dump_code()
 {
 	for(int i = 0; i < vm_code_size; i++) {
-		printf("%p %lu\n", vm_code+i, vm_code[i]);
+		printf("%p %" PRIu64 "\n", vm_code+i, vm_code[i]);
 	}
 }
 

--- a/gc.c
+++ b/gc.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 //#define TIME_GC
 #ifdef TIME_GC
@@ -119,9 +120,9 @@ struct timeval gc_timer_tmp;
 #endif
 
 void gc_report() {
-	printf("GC REPORT: %lu collections\n", gc_iterations);
+	printf("GC REPORT: %" PRIu64 " collections\n", gc_iterations);
 #ifdef TIME_GC
-	printf("GC REPORT: %lu%% of time spent in GC\n", (100*gc_time_inside)/(gc_time_inside + gc_time_outside));
+	printf("GC REPORT: %" PRIu64 "%% of time spent in GC\n", (100*gc_time_inside)/(gc_time_inside + gc_time_outside));
 #endif
 }
 

--- a/interpreter.c
+++ b/interpreter.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "qcodes.h"
 #include "objects.h"
@@ -173,7 +174,7 @@ void vm_exec(scm *codexxx) {
 		break;
 	default:
 		stack_trace();
-		fprintf(stderr, "call: not a closure 0x%lx %ld\n", reg_acc, scm_gettag(reg_acc));
+		fprintf(stderr, "call: not a closure 0x%" PRIx64 " %" PRId64 "\n", reg_acc, scm_gettag(reg_acc));
 		exit(1);
 	}
 	NEXT;


### PR DESCRIPTION
Needed to build on macos, for example.